### PR TITLE
Add WEATHER_LOCATION override with geocoding and unit handling

### DIFF
--- a/badge/secrets.py
+++ b/badge/secrets.py
@@ -12,3 +12,18 @@ GITHUB_USERNAME = ""
 # With token: 5000 requests/hour
 # Docs here https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
 GITHUB_TOKEN = ""
+
+# Optional: Override weather location (by default it's auto-detected from IP)
+# You can specify location in several ways:
+#
+# By city name (simple):
+# WEATHER_LOCATION = "Tokyo"
+#
+# By city and country (tuple):
+# WEATHER_LOCATION = ("London", "GB")
+#
+# By exact coordinates (tuple):
+# WEATHER_LOCATION = (51.5074, -0.1278, "London", "GB")
+#
+# Leave unset or set to None to use auto-detection (default):
+# WEATHER_LOCATION = None


### PR DESCRIPTION
- Add WEATHER_LOCATION config and import it from secrets.py
- Implement geocode_city() (Nominatim) to resolve city names
- Let detect_location accept dict/tuple/string overrides (coords or city) and use them
- Add use_mph flag and propagate wind unit to fetch/draw logic
- Update unit toggle to cycle: F+mph → C+mph → C+kmh → F+mph
- Document WEATHER_LOCATION examples in secrets.py