### PR TITLE
Fix menu pagination text vertical alignment

### DIFF
--- a/badge/apps/menu/__init__.py
+++ b/badge/apps/menu/__init__.py
@@ -140,7 +140,7 @@ def update():
         page_label = f"{current_page + 1}/{total_pages}"
         w, _ = screen.measure_text(page_label)
         screen.brush = brushes.color(211, 250, 55, 150)
-        screen.text(page_label, 160 - w - 5, 112)
+        screen.text(page_label, 160 - w - 5, 108)
 
     if alpha <= MAX_ALPHA:
         screen.brush = brushes.color(0, 0, 0, 255 - alpha)


### PR DESCRIPTION
The `1/2` pagination text added in the [Paginate the Launcher](https://badger.github.io/hack/menu-pagination/) hack is too low on the screen and is slightly cut off. This moves it up slightly to ensure it is safely rendered between the bottom row of icons and the bottom edge of the screen.

Specific to the Tufty 2350 (Universe '25) badge.